### PR TITLE
Fix packing slip button markup

### DIFF
--- a/greenangel-hub/modules/packing-slips.php
+++ b/greenangel-hub/modules/packing-slips.php
@@ -124,12 +124,12 @@ function greenangel_render_packing_slips_tab() {
               <td>
                 <button type="button"
                         onclick="printSingleOrder(<?php echo $id; ?>,'slips')"
-                        class="action-btn">🖨️</button>
+                        class="action-btn">🖨</button>️</button>
               </td>
               <td>
                 <button type="button"
                         onclick="printSingleOrder(<?php echo $id; ?>,'labels')"
-                        class="action-btn">🏷️</button>
+                        class="action-btn">🏷</button>️</button>
               </td>
             </tr>
           <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- close `<button>` tags for single-order actions in packing slip module

## Testing
- `git diff --color --unified=5 modules/packing-slips.php`