### PR TITLE
Fix Affiliates navigation integration

### DIFF
--- a/greenangel-hub/generate-affiliate-letter.php
+++ b/greenangel-hub/generate-affiliate-letter.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Affiliate Welcome Letter generator
+ */
+
+if ( ! defined('ABSPATH') ) {
+    exit; // no direct access
+}
+
+if ( ! current_user_can('manage_woocommerce') ) {
+    wp_die('Permission denied');
+}
+
+$affiliate_id = isset($_GET['affiliate_id']) ? intval($_GET['affiliate_id']) : 0;
+if ( ! $affiliate_id ) {
+    wp_die('Missing affiliate_id');
+}
+
+function ga_get_affiliate($affiliate_id) {
+    if ( function_exists('slicewp_get_affiliate') ) {
+        return slicewp_get_affiliate($affiliate_id);
+    }
+    global $wpdb;
+    $table = $wpdb->prefix . 'slicewp_affiliates';
+    return $wpdb->get_row( $wpdb->prepare("SELECT * FROM $table WHERE affiliate_id = %d", $affiliate_id) );
+}
+
+$affiliate = ga_get_affiliate($affiliate_id);
+if ( ! $affiliate ) {
+    wp_die('Affiliate not found');
+}
+
+$user = get_user_by('ID', $affiliate->user_id);
+if ( ! $user ) {
+    wp_die('User not found');
+}
+
+$name = $user->display_name ? $user->display_name : $user->user_email;
+$email = $user->user_email;
+$slug  = get_user_meta($user->ID, 'slice_referral_slug', true);
+if ( empty($slug) && isset($affiliate->slug) ) {
+    $slug = $affiliate->slug;
+}
+$ref_url = home_url('/ref/' . $slug);
+
+?><!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Affiliate Welcome Letter</title>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+body{font-family:'Poppins',sans-serif;background:#fff;color:#222222;padding:40px;}
+.h1{color:#aed604;}
+.bubble{background:#aed604;color:#222222;border-radius:20px;padding:10px 20px;display:inline-block;margin-bottom:20px;}
+</style>
+</head>
+<body>
+<div class="bubble"><strong>Green Angel Affiliate Program</strong></div>
+<h1>Hello <?php echo esc_html($name); ?>!</h1>
+<p>We're excited to have you as part of the community.</p>
+<p>Your referral link:<br><strong><?php echo esc_html($ref_url); ?></strong></p>
+<p>Keep flying high with Green Angel. Replace this text with your own welcome message.</p>
+<script>window.onload=()=>window.print();</script>
+</body>
+</html>

--- a/greenangel-hub/greenangel-hub.php
+++ b/greenangel-hub/greenangel-hub.php
@@ -16,6 +16,7 @@ require_once plugin_dir_path(__FILE__) . 'modules/nfc-manager.php';
 require_once plugin_dir_path(__FILE__) . 'modules/packing-slips.php';
 require_once plugin_dir_path(__FILE__) . 'modules/code-manager/tab.php'; // 💫 Angel Code Manager tab
 require_once plugin_dir_path(__FILE__) . 'modules/tools.php'; // 🛠 Tools tab
+require_once plugin_dir_path(__FILE__) . 'modules/affiliates.php'; // 🤝 Affiliates page
 
 // ✅ Load DB installer
 require_once plugin_dir_path(__FILE__) . 'includes/db-install.php';
@@ -135,6 +136,7 @@ function greenangel_hub_page() {
     echo '<a href="?page=greenangel-hub&tab=packing-slips" class="nav-tab ' . ($active_tab === 'packing-slips' ? 'nav-tab-active' : '') . '">📦 Packing Slips</a>';
     echo '<a href="?page=greenangel-hub&tab=angel-codes" class="nav-tab ' . ($active_tab === 'angel-codes' ? 'nav-tab-active' : '') . '">🪽 Angel Codes</a>';
     echo '<a href="?page=greenangel-hub&tab=tools" class="nav-tab ' . ($active_tab === 'tools' ? 'nav-tab-active' : '') . '">🛠 Tools</a>';
+    echo '<a href="?page=greenangel-hub&tab=affiliates" class="nav-tab ' . ($active_tab === 'affiliates' ? 'nav-tab-active' : '') . '">🤝 Affiliates</a>';
     echo '</div>';
 
     // 🧠 Tab Renderer
@@ -148,6 +150,8 @@ function greenangel_hub_page() {
         greenangel_render_angel_codes_tab(); // ✅ NEW RENDER FUNCTION
     } elseif ($active_tab === 'tools') {
         greenangel_render_tools_tab();
+    } elseif ($active_tab === 'affiliates') {
+        greenangel_render_affiliates_page();
     }
 
     echo '</div>';

--- a/greenangel-hub/modules/affiliates.php
+++ b/greenangel-hub/modules/affiliates.php
@@ -1,0 +1,101 @@
+<?php
+// 🌿 Green Angel Hub – Affiliates Subpage
+
+// Register submenu page so it's accessible from the WP menu
+add_action('admin_menu', function () {
+    add_submenu_page(
+        'greenangel-hub',
+        'Affiliates',
+        'Affiliates',
+        'manage_woocommerce',
+        'greenangel-affiliates',
+        'greenangel_render_affiliates_page'
+    );
+});
+
+function greenangel_fetch_affiliates() {
+    if (function_exists('slicewp_get_affiliates')) {
+        return slicewp_get_affiliates(['number' => -1, 'status' => 'active']);
+    }
+    global $wpdb;
+    $table = $wpdb->prefix . 'slicewp_affiliates';
+    return $wpdb->get_results("SELECT * FROM $table WHERE status = 'active'");
+}
+
+function greenangel_render_affiliates_page() {
+    if (!current_user_can('manage_woocommerce')) {
+        wp_die('Permission denied');
+    }
+
+    $search = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
+    $affiliates = greenangel_fetch_affiliates();
+
+    if ($search) {
+        $search_lc = strtolower($search);
+        $affiliates = array_filter($affiliates, function($aff) use ($search_lc) {
+            $user = get_user_by('ID', $aff->user_id);
+            if (!$user) return false;
+            $name = $user->display_name;
+            $email = $user->user_email;
+            return (stripos($name, $search_lc) !== false) || (stripos($email, $search_lc) !== false);
+        });
+    }
+
+    echo '<div class="affiliate-wrap">';
+    echo '<div class="title-bubble">💚 Affiliates</div>';
+
+    $is_tab = (isset($_GET['page']) && $_GET['page'] === 'greenangel-hub');
+    echo '<form method="get" class="search-bar">';
+    if ($is_tab) {
+        echo '<input type="hidden" name="page" value="greenangel-hub">';
+        echo '<input type="hidden" name="tab" value="affiliates">';
+    } else {
+        echo '<input type="hidden" name="page" value="greenangel-affiliates">';
+    }
+    echo '<input type="text" name="s" value="' . esc_attr($search) . '" placeholder="Search affiliates...">';
+    echo '<button type="submit">Search</button>';
+    echo '</form>';
+
+    echo '<table class="aff-table">';
+    echo '<thead><tr>';
+    echo '<th><span class="header-bubble">Affiliate</span></th>';
+    echo '<th><span class="header-bubble">Email</span></th>';
+    echo '<th><span class="header-bubble">Referral Link</span></th>';
+    echo '<th><span class="header-bubble">Letter</span></th>';
+    echo '</tr></thead><tbody>';
+
+    foreach ($affiliates as $aff) {
+        $user = get_user_by('ID', $aff->user_id);
+        if (!$user) continue;
+        $name = $user->display_name ?: $user->user_email;
+        $email = $user->user_email;
+        $slug = get_user_meta($user->ID, 'slice_referral_slug', true);
+        if (empty($slug) && isset($aff->slug)) $slug = $aff->slug;
+        $ref_url = home_url('/ref/' . $slug);
+        $print_url = esc_url(plugins_url('../generate-affiliate-letter.php', __FILE__) . '?affiliate_id=' . intval($aff->affiliate_id));
+        echo '<tr>';
+        echo '<td>' . esc_html($name) . '</td>';
+        echo '<td>' . esc_html($email) . '</td>';
+        echo '<td><code>' . esc_html($ref_url) . '</code></td>';
+        echo '<td><a class="letter-btn" href="' . $print_url . '" target="_blank">Print</a></td>';
+        echo '</tr>';
+    }
+
+    echo '</tbody></table></div>';
+
+    echo '<style>
+        .affiliate-wrap {font-family:"Poppins",sans-serif!important;}
+        .search-bar {margin-bottom:20px;}
+        .search-bar input[type=text] {padding:8px 12px;border-radius:20px;border:1px solid rgba(174,214,4,0.3);background:#222;color:#fff;}
+        .search-bar button {background:#aed604;color:#222;border:none;padding:8px 16px;border-radius:20px;font-weight:500;cursor:pointer;margin-left:6px;}
+        .aff-table {width:100%;border-collapse:separate;border-spacing:0;border-radius:14px;overflow:hidden;margin-top:10px;font-family:"Poppins",sans-serif!important;}
+        .aff-table th,.aff-table td {padding:12px 14px;text-align:center;}
+        .aff-table th {background:#222;color:#aed604;}
+        .aff-table td {background:#222;color:#fff;}
+        .aff-table tbody tr:hover td {background:#2a2a2a;}
+        .header-bubble {background:#aed604;color:#222;padding:6px 12px;border-radius:16px;font-weight:500;font-size:12px;white-space:nowrap;}
+        .letter-btn {background:#aed604;color:#222;border-radius:20px;padding:6px 12px;text-decoration:none;display:inline-block;font-size:13px;transition:.2s;}
+        .letter-btn:hover {transform:scale(1.05);color:#222;}
+        .aff-table code {background:rgba(255,255,255,0.1);padding:6px 8px;border-radius:8px;display:inline-block;color:#aed604;}
+    </style>';
+}


### PR DESCRIPTION
## Summary
- adjust Affiliates module to render in-tab or standalone
- add Affiliates tab link to the Hub navigation
- route Affiliates tab through hub switch case

## Testing
- `php` was not available, so syntax checks could not be run