### PR TITLE
Implement nonce checks for Angel Code actions

### DIFF
--- a/greenangel-hub/modules/code-manager/manage-code.php
+++ b/greenangel-hub/modules/code-manager/manage-code.php
@@ -2,28 +2,56 @@
 // 🌿 Green Angel — Toggle & Delete Angel Codes
 
 add_action('admin_post_greenangel_toggle_code', function () {
-    if (!current_user_can('manage_woocommerce') || empty($_GET['id'])) return;
+    if (!current_user_can('manage_woocommerce')) {
+        wp_die('Nope');
+    }
+
+    $redirect = admin_url('admin.php?page=greenangel-hub&tab=angel-codes');
+    $id = intval($_GET['id'] ?? 0);
+
+    if (!$id) {
+        wp_redirect(add_query_arg('code', 'invalid', $redirect));
+        exit;
+    }
+
+    if (!check_admin_referer('greenangel_toggle_code', '_wpnonce', false)) {
+        wp_redirect(add_query_arg('nonce', 'failed', $redirect));
+        exit;
+    }
 
     global $wpdb;
-    $id = intval($_GET['id']);
     $table = $wpdb->prefix . 'greenangel_codes';
 
-    $current = $wpdb->get_var("SELECT active FROM $table WHERE id = $id");
+    $current = $wpdb->get_var($wpdb->prepare("SELECT active FROM $table WHERE id = %d", $id));
     $new = $current ? 0 : 1;
 
     $wpdb->update($table, ['active' => $new], ['id' => $id]);
-    wp_redirect(admin_url('admin.php?page=greenangel-hub&tab=angel-codes'));
+    wp_redirect($redirect);
     exit;
 });
 
 add_action('admin_post_greenangel_delete_code', function () {
-    if (!current_user_can('manage_woocommerce') || empty($_GET['id'])) return;
+    if (!current_user_can('manage_woocommerce')) {
+        wp_die('Nope');
+    }
+
+    $redirect = admin_url('admin.php?page=greenangel-hub&tab=angel-codes');
+    $id = intval($_GET['id'] ?? 0);
+
+    if (!$id) {
+        wp_redirect(add_query_arg('code', 'invalid', $redirect));
+        exit;
+    }
+
+    if (!check_admin_referer('greenangel_delete_code', '_wpnonce', false)) {
+        wp_redirect(add_query_arg('nonce', 'failed', $redirect));
+        exit;
+    }
 
     global $wpdb;
-    $id = intval($_GET['id']);
     $table = $wpdb->prefix . 'greenangel_codes';
 
     $wpdb->delete($table, ['id' => $id]);
-    wp_redirect(admin_url('admin.php?page=greenangel-hub&tab=angel-codes'));
+    wp_redirect($redirect);
     exit;
 });

--- a/greenangel-hub/modules/code-manager/table-codes.php
+++ b/greenangel-hub/modules/code-manager/table-codes.php
@@ -154,8 +154,14 @@ function greenangel_render_code_table() {
         echo '<td>' . esc_html(date('Y-m-d', strtotime($code->created_at))) . '</td>';
 
         // Actions
-        $toggle_url = admin_url("admin-post.php?action=greenangel_toggle_code&id={$code->id}");
-        $delete_url = admin_url("admin-post.php?action=greenangel_delete_code&id={$code->id}");
+        $toggle_url = wp_nonce_url(
+            admin_url("admin-post.php?action=greenangel_toggle_code&id={$code->id}"),
+            'greenangel_toggle_code'
+        );
+        $delete_url = wp_nonce_url(
+            admin_url("admin-post.php?action=greenangel_delete_code&id={$code->id}"),
+            'greenangel_delete_code'
+        );
         echo '<td><div class="actions-wrap">';
         $active_class = $code->active ? 'status-toggle' : 'status-toggle inactive';
         echo '<a href="'.esc_url($toggle_url).'" class="'.$active_class.'" title="Toggle Active">';


### PR DESCRIPTION
## Summary
- secure `greenangel_toggle_code` and `greenangel_delete_code` actions with `check_admin_referer`
- validate the ID and redirect on nonce failure
- append nonces to action URLs in `table-codes.php`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860e6ba06848326999a8bd16b1b8d09