### PR TITLE
Add nonce check in registration handler

### DIFF
--- a/greenangel-hub/modules/code-manager/handle-registration.php
+++ b/greenangel-hub/modules/code-manager/handle-registration.php
@@ -7,6 +7,12 @@ function greenangel_handle_registration() {
     error_log("💥 Running registration handler...");
     
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') return;
+
+    if (!check_admin_referer('woocommerce-register', 'woocommerce-register-nonce', false)) {
+        wp_safe_redirect(add_query_arg('greenangel_error', 'invalid_nonce', wc_get_page_permalink('myaccount')));
+        exit;
+    }
+
     global $wpdb;
     
     // 🧼 Sanitize inputs
@@ -145,6 +151,9 @@ function greenangel_show_popup_messages() {
                 break;
             case 'failed':
                 $message = 'Sorry, we couldn\'t create your account. Please try again.';
+                break;
+            case 'invalid_nonce':
+                $message = 'Security check failed. Please try again.';
                 break;
             default:
                 $message = 'Something unexpected happened. Please try again.';


### PR DESCRIPTION
## Summary
- verify WooCommerce register nonce in `greenangel_handle_registration()`
- add error handling for nonce failures

## Testing
- `php -l greenangel-hub/modules/code-manager/handle-registration.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860ea1dc5548326af44fae011d09b53