### PR TITLE
Secure log management actions with nonces

### DIFF
--- a/greenangel-hub/modules/code-manager/manage-logs.php
+++ b/greenangel-hub/modules/code-manager/manage-logs.php
@@ -8,6 +8,7 @@ function esc_csv($value) {
 // Clear usage log
 add_action('admin_post_greenangel_clear_usage_log', function () {
     if (!current_user_can('manage_woocommerce')) wp_die('Permission denied');
+    check_admin_referer('greenangel_clear_usage_log');
     global $wpdb;
     $wpdb->query('TRUNCATE TABLE ' . $wpdb->prefix . 'greenangel_code_logs');
     wp_redirect(admin_url('admin.php?page=greenangel-hub&tab=angel-codes&log_cleared=1'));
@@ -17,6 +18,7 @@ add_action('admin_post_greenangel_clear_usage_log', function () {
 // Download usage log as CSV
 add_action('admin_post_greenangel_download_usage_log', function () {
     if (!current_user_can('manage_woocommerce')) wp_die('Permission denied');
+    check_admin_referer('greenangel_download_usage_log');
     global $wpdb;
     $table = $wpdb->prefix . 'greenangel_code_logs';
     $logs  = $wpdb->get_results("SELECT * FROM $table ORDER BY timestamp DESC");
@@ -32,6 +34,7 @@ add_action('admin_post_greenangel_download_usage_log', function () {
 // Clear failed attempts log
 add_action('admin_post_greenangel_clear_failed_log', function () {
     if (!current_user_can('manage_woocommerce')) wp_die('Permission denied');
+    check_admin_referer('greenangel_clear_failed_log');
     global $wpdb;
     $wpdb->query('TRUNCATE TABLE ' . $wpdb->prefix . 'greenangel_failed_code_attempts');
     wp_redirect(admin_url('admin.php?page=greenangel-hub&tab=angel-codes&failed_cleared=1'));
@@ -41,6 +44,7 @@ add_action('admin_post_greenangel_clear_failed_log', function () {
 // Download failed attempts log as CSV
 add_action('admin_post_greenangel_download_failed_log', function () {
     if (!current_user_can('manage_woocommerce')) wp_die('Permission denied');
+    check_admin_referer('greenangel_download_failed_log');
     global $wpdb;
     $table = $wpdb->prefix . 'greenangel_failed_code_attempts';
     $logs  = $wpdb->get_results("SELECT * FROM $table ORDER BY timestamp DESC");

--- a/greenangel-hub/modules/code-manager/table-fails.php
+++ b/greenangel-hub/modules/code-manager/table-fails.php
@@ -82,10 +82,12 @@ function greenangel_render_failed_code_log() {
     echo '<div class="title-bubble" style="margin-top:30px; margin-bottom:12px;">🚫 Failed Angel Code Attempts</div>';
     echo '<div class="log-controls">';
     echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+    echo wp_nonce_field('greenangel_clear_failed_log', '_wpnonce', true, false);
     echo '<input type="hidden" name="action" value="greenangel_clear_failed_log">';
     echo '<button type="submit" class="log-bubble-button">🗑 Clear Log</button>';
     echo '</form>';
     echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+    echo wp_nonce_field('greenangel_download_failed_log', '_wpnonce', true, false);
     echo '<input type="hidden" name="action" value="greenangel_download_failed_log">';
     echo '<button type="submit" class="log-bubble-button">📥 Download CSV</button>';
     echo '</form>';

--- a/greenangel-hub/modules/code-manager/table-logs.php
+++ b/greenangel-hub/modules/code-manager/table-logs.php
@@ -1,29 +1,55 @@
 <?php
-// 🌿 Green Angel – Angel Code Log Viewer (Clean Version)
+// 🌿 Green Angel – Angel Code Usage Log
 function greenangel_render_code_log_table() {
     global $wpdb;
     $table = $wpdb->prefix . 'greenangel_code_logs';
-    $logs = $wpdb->get_results("SELECT * FROM $table ORDER BY timestamp DESC LIMIT 50");
-    
-    if (!$logs) {
-        ?>
-        <div class="empty-state">
-            <div class="empty-state-icon">🌙</div>
-            <p>No registrations logged yet</p>
-            <p style="opacity: 0.6; font-size: 13px;">This will populate once someone registers using a valid code.</p>
-        </div>
-        <?php
-        return;
-    }
+    $logs  = $wpdb->get_results("SELECT * FROM $table ORDER BY timestamp DESC LIMIT 50");
+
+    echo '<div class="log-section">';
     ?>
-    
     <style>
+        .log-section {
+            margin-top: 30px;
+        }
+        .log-controls {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 12px;
+            align-items: center;
+        }
+        .log-bubble-button {
+            background: #222;
+            color: #aed604;
+            border: none;
+            padding: 8px 18px;
+            font-weight: 500;
+            cursor: pointer;
+            border-radius: 20px;
+            transition: all 0.2s ease-in-out;
+            font-family: "Poppins", sans-serif !important;
+            font-size: 13px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            box-shadow: 0 0 0 rgba(174,214,4,0);
+        }
+        .log-bubble-button:hover {
+            box-shadow: 0 0 8px rgba(174,214,4,0.7);
+            transform: translateY(-2px);
+        }
+        .empty-log {
+            text-align: center;
+            padding: 30px;
+            background: #222;
+            border-radius: 14px;
+            margin-top: 20px;
+            color: #fff;
+        }
         .log-table {
             width: 100%;
             border-collapse: collapse;
             font-family: 'Poppins', sans-serif;
         }
-        
         .log-table th {
             background: rgba(174, 214, 4, 0.1);
             color: #aed604;
@@ -35,57 +61,63 @@ function greenangel_render_code_log_table() {
             letter-spacing: 1px;
             border-bottom: 2px solid rgba(174, 214, 4, 0.2);
         }
-        
         .log-table td {
             padding: 12px;
             color: #fff;
             border-bottom: 1px solid #333;
         }
-        
         .log-table tbody tr:hover {
             background: rgba(255, 255, 255, 0.02);
         }
-        
         .log-table .code-column {
             font-weight: 600;
             color: #aed604;
             font-family: monospace;
         }
-        
         .log-table .time-column {
             color: #888;
             font-size: 13px;
         }
-        
         @media (max-width: 768px) {
             .log-table {
                 font-size: 13px;
             }
-            
             .log-table th,
             .log-table td {
                 padding: 8px;
             }
         }
     </style>
-    
-    <table class="log-table">
-        <thead>
-            <tr>
-                <th>Email</th>
-                <th>Code Used</th>
-                <th>Timestamp</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($logs as $log): ?>
-                <tr>
-                    <td><?php echo esc_html($log->email ?: '—'); ?></td>
-                    <td class="code-column"><?php echo esc_html($log->code_used); ?></td>
-                    <td class="time-column"><?php echo esc_html(date('Y-m-d H:i', strtotime($log->timestamp))); ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
     <?php
+    echo '<div class="title-bubble" style="margin-top:30px; margin-bottom:12px;">📊 Usage Log</div>';
+    echo '<div class="log-controls">';
+    echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+    echo wp_nonce_field('greenangel_clear_usage_log', '_wpnonce', true, false);
+    echo '<input type="hidden" name="action" value="greenangel_clear_usage_log">';
+    echo '<button type="submit" class="log-bubble-button">🗑 Clear Log</button>';
+    echo '</form>';
+    echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+    echo wp_nonce_field('greenangel_download_usage_log', '_wpnonce', true, false);
+    echo '<input type="hidden" name="action" value="greenangel_download_usage_log">';
+    echo '<button type="submit" class="log-bubble-button">📥 Download CSV</button>';
+    echo '</form>';
+    echo '</div>';
+
+    if (!$logs) {
+        echo '<div class="empty-log">';
+        echo '<p style="font-size:16px;">No registrations logged yet 🌙</p>';
+        echo '</div></div>';
+        return;
+    }
+
+    echo '<table class="log-table">';
+    echo '<thead><tr><th>Email</th><th>Code Used</th><th>Timestamp</th></tr></thead><tbody>';
+    foreach ($logs as $log) {
+        echo '<tr>';
+        echo '<td>' . esc_html($log->email ?: '—') . '</td>';
+        echo '<td class="code-column">' . esc_html($log->code_used) . '</td>';
+        echo '<td class="time-column">' . esc_html(date('Y-m-d H:i', strtotime($log->timestamp))) . '</td>';
+        echo '</tr>';
+    }
+    echo '</tbody></table></div>';
 }


### PR DESCRIPTION
## Summary
- check `check_admin_referer()` in log management handlers
- include nonce fields in failed log forms
- add usage log controls with nonce protected forms

## Testing
- `php -l modules/code-manager/manage-logs.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e9eb314083269b789a7902c34f6f