### PR TITLE
Implement caching for email lookups

### DIFF
--- a/greenangel-hub/modules/nfc-manager.php
+++ b/greenangel-hub/modules/nfc-manager.php
@@ -479,27 +479,36 @@ function greenangel_render_nfc_card_manager() {
     }
 
     // Process orders data
-    $orders_data = [];
+    $orders_data          = [];
+    $email_orders_cache   = [];
+    $referral_code_cache  = [];
+
     foreach ($orders as $order) {
         $id = $order->get_id();
         $name = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
         $email = $order->get_billing_email();
         $total = floatval($order->get_total());
         $spend = 0;
-        
+
         // Get customer history
-        $customer_orders = wc_get_orders([
-            'billing_email' => $email,
-            'status' => ['completed', 'processing', 'on-hold', 'ship-today'],
-            'limit' => -1,
-        ]);
+        if ( ! isset( $email_orders_cache[ $email ] ) ) {
+            $email_orders_cache[ $email ] = wc_get_orders([
+                'billing_email' => $email,
+                'status'       => ['completed', 'processing', 'on-hold', 'ship-today'],
+                'limit'        => -1,
+            ]);
+        }
+        $customer_orders = $email_orders_cache[ $email ];
         
         foreach ($customer_orders as $co) {
             $spend += floatval($co->get_total());
         }
         
         // Get referral code
-        $referral_code = greenangel_get_loyalty_referral_code($email);
+        if ( ! isset( $referral_code_cache[ $email ] ) ) {
+            $referral_code_cache[ $email ] = greenangel_get_loyalty_referral_code( $email );
+        }
+        $referral_code = $referral_code_cache[ $email ];
         $referral_url = $referral_code ? "https://greenangelshop.com?wlr_ref={$referral_code}" : null;
         
         // Card status


### PR DESCRIPTION
## Summary
- improve `greenangel_render_nfc_card_manager` performance
- cache customer history lookups per email
- cache loyalty referral codes per email

## Testing
- `php -l greenangel-hub/modules/nfc-manager.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f12abca083268c4d542df39e7f58