### PR TITLE
Remove debug logs and load styles conditionally

### DIFF
--- a/greenangel-hub/account/account-dashboard.php
+++ b/greenangel-hub/account/account-dashboard.php
@@ -24,14 +24,16 @@ function greenangel_enqueue_account_dashboard_styles() {
 }
 
 // 🌿 BACKUP: Always load (debug)
-add_action('wp_enqueue_scripts', 'greenangel_force_enqueue_account_dashboard_styles', 20);
-function greenangel_force_enqueue_account_dashboard_styles() {
-    wp_enqueue_style(
-        'greenangel-account-dashboard-force',
-        plugin_dir_url(__FILE__) . 'account-dashboard.css',
-        [],
-        time()
-    );
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+    add_action( 'wp_enqueue_scripts', 'greenangel_force_enqueue_account_dashboard_styles', 20 );
+    function greenangel_force_enqueue_account_dashboard_styles() {
+        wp_enqueue_style(
+            'greenangel-account-dashboard-force',
+            plugin_dir_url( __FILE__ ) . 'account-dashboard.css',
+            [],
+            time()
+        );
+    }
 }
 
 // 🌿 WP LOYALTY POINTS - FIXED COLUMN NAMES!
@@ -98,7 +100,7 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
     
     // First, let's check if WP Loyalty has its own function we can use
     if (class_exists('Wlr\App\Helpers\EarnCampaign')) {
-        error_log('DEBUG: WP Loyalty class exists - checking for built-in methods');
+        // Future: utilise built-in methods if available.
     }
     
     // Define all possible activity tables
@@ -120,12 +122,6 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
             LIMIT 10
         ", $email));
         
-        error_log('DEBUG: Sample log entry structure:');
-        if (!empty($test_query)) {
-            foreach ($test_query[0] as $key => $value) {
-                error_log("  $key => $value");
-            }
-        }
         
         // Now get the actual data
         $log_activities = $wpdb->get_results($wpdb->prepare("
@@ -155,7 +151,7 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
             }
         }
         
-        error_log('DEBUG: Log activities found: ' . count($log_activities));
+        // Debug: log count of activities retrieved if needed.
     }
     
     // 2. Get from earn campaign transactions (for any missing activities)
@@ -201,7 +197,7 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
             }
         }
         
-        error_log('Earn transactions found: ' . count($earn_activities) . ' (added: ' . (count($all_activities) - count($log_activities)) . ')');
+        // Debug: log earn transaction count here if needed.
     }
     
     // 3. Get from reward transactions (redemptions)
@@ -245,7 +241,7 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
             }
         }
         
-        error_log('Reward transactions found: ' . count($reward_activities));
+        // Debug: log reward transaction count if needed.
     }
     
     // 4. Get from points ledger (for any additional activities)
@@ -291,7 +287,7 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
             }
         }
         
-        error_log('Points ledger found: ' . count($ledger_activities));
+        // Debug: log ledger activity count if needed.
     }
     
     // Sort all activities by date (newest first)
@@ -304,7 +300,7 @@ function greenangel_get_recent_activities($user_id, $limit = 100) {
     // Limit results
     $all_activities = array_slice($all_activities, 0, $limit);
     
-    error_log('Total unique activities returned: ' . count($all_activities));
+    // Debug: log overall activity count if needed.
     
     return $all_activities;
 }
@@ -361,12 +357,7 @@ function greenangel_account_dashboard() {
     // 🌟 GET RECENT ACTIVITIES - NOW WITH MORE DATA!
     $recent_activities = greenangel_get_recent_activities($user_id, 200); // Increased limit to ensure we get all
     
-    // DEBUG: Let's see what we're getting
-    error_log('DEBUG: Total activities fetched: ' . count($recent_activities));
-    error_log('DEBUG: Activities breakdown:');
-    foreach ($recent_activities as $idx => $act) {
-        error_log("Activity $idx: Type={$act->activity_type}, Points={$act->points}, Date={$act->created_at}, Source={$act->source}");
-    }
+    // Debug: inspect $recent_activities here if needed.
 
     // First order date
     $first_order_date = 'Not yet placed';

--- a/greenangel-hub/orders/orders-preview.php
+++ b/greenangel-hub/orders/orders-preview.php
@@ -2,38 +2,36 @@
 // 🌿 Enqueue orders preview styles
 add_action('wp_enqueue_scripts', 'greenangel_enqueue_orders_preview_styles');
 function greenangel_enqueue_orders_preview_styles() {
-    if (!is_singular()) return; // Only load on pages/posts
+    if ( ! is_singular() ) {
+        return; // Only load on pages/posts
+    }
+
     global $post;
-    
-    // 🔍 DEBUG: Let's see what's happening
-    error_log('🌿 DEBUG: Checking for shortcode on page: ' . $post->post_title);
-    error_log('🌿 DEBUG: Post content preview: ' . substr($post->post_content, 0, 200));
-    
-    if (has_shortcode($post->post_content, 'greenangel_orders_preview')) {
-        error_log('🌿 DEBUG: Shortcode found! Enqueueing CSS...');
+
+    // Debug helper: inspect page context if needed.
+
+    if ( has_shortcode( $post->post_content, 'greenangel_orders_preview' ) ) {
         wp_enqueue_style(
             'greenangel-orders-preview',
-            plugin_dir_url(__FILE__) . 'orders-preview.css',
+            plugin_dir_url( __FILE__ ) . 'orders-preview.css',
             [],
             '1.0'
         );
-        error_log('🌿 DEBUG: CSS URL: ' . plugin_dir_url(__FILE__) . 'orders-preview.css');
-    } else {
-        error_log('🌿 DEBUG: Shortcode NOT found!');
+        // Debug: check CSS URL when troubleshooting
     }
 }
 
-// 🌿 BACKUP: Always load on specific pages (temporary debug)
-add_action('wp_enqueue_scripts', 'greenangel_force_enqueue_orders_styles', 20);
-function greenangel_force_enqueue_orders_styles() {
-    // Force load CSS on any page containing our shortcode output
-    wp_enqueue_style(
-        'greenangel-orders-preview-force',
-        plugin_dir_url(__FILE__) . 'orders-preview.css',
-        [],
-        time() // Cache busting
-    );
-    error_log('🌿 DEBUG: Force-enqueued CSS with timestamp: ' . time());
+// 🌿 Optional debug loader
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+    add_action( 'wp_enqueue_scripts', 'greenangel_force_enqueue_orders_styles', 20 );
+    function greenangel_force_enqueue_orders_styles() {
+        wp_enqueue_style(
+            'greenangel-orders-preview-force',
+            plugin_dir_url( __FILE__ ) . 'orders-preview.css',
+            [],
+            time() // Cache busting
+        );
+    }
 }
 
 // 🌿 Green Angel Hub – Orders Preview


### PR DESCRIPTION
## Summary
- ensure dashboard and order preview styles only load when shortcodes are present
- remove stray `error_log` calls from account and order preview templates
- wrap fallback style loaders in WP_DEBUG checks

## Testing
- `php -l greenangel-hub/account/account-dashboard.php` *(fails: command not found)*
- `php -l greenangel-hub/orders/orders-preview.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f24c64348326889066f0d268de14