### PR TITLE
Fix WooCommerce subtotal usage

### DIFF
--- a/greenangel-hub/modules/postcode-rules/enforce-checkout.php
+++ b/greenangel-hub/modules/postcode-rules/enforce-checkout.php
@@ -4,7 +4,8 @@
 add_action('woocommerce_after_checkout_validation', 'greenangel_enforce_postcode_rules', 10, 2);
 function greenangel_enforce_postcode_rules($fields, $errors) {
     $postcode = strtoupper(str_replace(' ', '', $fields['shipping_postcode']));
-    $cart_total = WC()->cart->subtotal;
+    // Use getter method in case WC changes property visibility
+    $cart_total = WC()->cart->get_subtotal();
     
     global $wpdb;
     $table = $wpdb->prefix . 'greenangel_postcode_rules';


### PR DESCRIPTION
## Summary
- use WC getter method for cart subtotal in postcode rules

## Testing
- `php -l greenangel-hub/modules/postcode-rules/enforce-checkout.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860fc4d6eb48326ab0078e6ddfc4da8