### PR TITLE
Fix unmatched brace in registration hooks file

### DIFF
--- a/greenangel-hub/modules/code-manager/registration-hooks.php
+++ b/greenangel-hub/modules/code-manager/registration-hooks.php
@@ -218,4 +218,3 @@ function greenangel_validate_birthday_fields($errors, $user) {
 }
 
 // 🎂 Helper functions for birthday data
-}


### PR DESCRIPTION
## Summary
- fix unmatched closing brace in registration-hooks.php

## Testing
- `grep -o '{' greenangel-hub/modules/code-manager/registration-hooks.php | wc -l`
- `grep -o '}' greenangel-hub/modules/code-manager/registration-hooks.php | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_686108aa98788326b645d6be40e4f7b2