### PR TITLE
Fix account dashboard CSS

### DIFF
--- a/greenangel-hub/account/account-dashboard.css
+++ b/greenangel-hub/account/account-dashboard.css
@@ -157,14 +157,6 @@
     margin-bottom: 1.5rem;
     text-align: center;
 }
-.ga-hero-section {
-    background: linear-gradient(135deg, #2a2a2a 0%, #333333 100%);
-    padding: 1.5rem;
-    border-radius: 16px;
-    border: 1px solid #444;
-    margin-bottom: 1.5rem;
-    text-align: center;
-}
 
 .ga-avatar-section {
     display: flex;
@@ -1249,9 +1241,9 @@
     }
     
     .ga-hero-message-wrapper {
-        flex: 1 1 300px;
+        flex: 1;
         max-width: 400px;
-        margin: 0;
+        margin: 0 auto;
     }
     
     .ga-points-section {


### PR DESCRIPTION
## Summary
- remove duplicate `.ga-hero-section` rules
- restore `.ga-hero-message-wrapper` styling
- keep mobile spacing for hero message wrapper and avatar section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68610e61433c8326bd8c6bdc152eaaef